### PR TITLE
Updating dom4j to 2.1.1 to resolve security vuln CVE-2018-1000632

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,9 @@
         </dependency>
 
         <dependency>
-            <groupId>dom4j</groupId>
+            <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>1.6.1</version>
+            <version>2.1.1</version>
             <optional>true</optional> <!-- case: when no xml de/serialization -->
         </dependency>
 


### PR DESCRIPTION
Signed-off-by: Chris Hupman <chupman@us.ibm.com>