### PR TITLE
Fix exception when descriptor of method is lambda method

### DIFF
--- a/src/main/java/org/reflections8/util/Utils.java
+++ b/src/main/java/org/reflections8/util/Utils.java
@@ -27,214 +27,243 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class Utils {
 
-  public static String repeat(String string, int times) {
-    StringBuilder sb = new StringBuilder();
-
-    for (int i = 0; i < times; i++) {
-      sb.append(string);
+    private Utils() {
+        // Utility class
     }
 
-    return sb.toString();
-  }
+    public static String repeat(String string, int times) {
+        StringBuilder sb = new StringBuilder();
 
-  /**
-   * isEmpty compatible with Java 5
-   */
-  public static boolean isEmpty(String s) {
-    return s == null || s.length() == 0;
-  }
-
-  public static boolean isEmpty(Object[] objects) {
-    return objects == null || objects.length == 0;
-  }
-
-  public static File prepareFile(String filename) {
-    File file = new File(filename);
-    File parent = file.getAbsoluteFile().getParentFile();
-    if (!parent.exists()) {
-      //noinspection ResultOfMethodCallIgnored
-      parent.mkdirs();
-    }
-    return file;
-  }
-
-  public static Member getMemberFromDescriptor(String descriptor, ClassLoader... classLoaders) throws ReflectionsException {
-    return getMemberFromDescriptor(descriptor, Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
-  }
-
-  public static Member getMemberFromDescriptor(String descriptor, Optional<ClassLoader[]> classLoaders) throws ReflectionsException {
-    int p0 = descriptor.lastIndexOf('(');
-    String memberKey = p0 != -1 ? descriptor.substring(0, p0) : descriptor;
-    String methodParameters = p0 != -1 ? descriptor.substring(p0 + 1, descriptor.lastIndexOf(')')) : "";
-
-    int p1 = Math.max(memberKey.lastIndexOf('.'), memberKey.lastIndexOf("$"));
-    String className = memberKey.substring(memberKey.lastIndexOf(' ') + 1, p1);
-    int endsWithLambda = memberKey.lastIndexOf(".lambda");
-    if (endsWithLambda > -1) {
-      className = className.substring(0, endsWithLambda);
-    }
-    String memberName = memberKey.substring(p1 + 1);
-
-    Class<?>[] parameterTypes = null;
-    if (!isEmpty(methodParameters)) {
-      String[] parameterNames = methodParameters.split(",");
-      List<Class<?>> result = new ArrayList<Class<?>>(parameterNames.length);
-      for (String name : parameterNames) {
-        result.add(forName(name.trim(), classLoaders));
-      }
-      parameterTypes = result.toArray(new Class<?>[result.size()]);
-    }
-
-    Class<?> aClass = forName(className, classLoaders);
-    while (aClass != null) {
-      try {
-        if (!descriptor.contains("(")) {
-          return aClass.isInterface() ? aClass.getField(memberName) : aClass.getDeclaredField(memberName);
-        } else if (isConstructor(descriptor)) {
-          return aClass.isInterface() ? aClass.getConstructor(parameterTypes) : aClass.getDeclaredConstructor(parameterTypes);
-        } else if (endsWithLambda == -1) {
-          return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes) : aClass.getDeclaredMethod(memberName, parameterTypes);
-        } else {
-          memberName = new StringBuilder("lambda$").append(memberName).toString();
-          return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes) : aClass.getDeclaredMethod(memberName, parameterTypes);
+        for (int i = 0; i < times; i++) {
+            sb.append(string);
         }
-      } catch (Exception e) {
-        aClass = aClass.getSuperclass();
-      }
+
+        return sb.toString();
     }
-    throw new ReflectionsException("Can't resolve member named " + memberName + " for class " + className);
-  }
 
-  public static Set<Method> getMethodsFromDescriptors(Iterable<String> annotatedWith, Optional<ClassLoader[]> classLoaders) {
-    Set<Method> result = new HashSet();
-    for (String annotated : annotatedWith) {
-      if (!isConstructor(annotated)) {
-        Method member = (Method) getMemberFromDescriptor(annotated, classLoaders);
-        if (member != null)
-          result.add(member);
-      }
+    /**
+     * isEmpty compatible with Java 5
+     */
+    public static boolean isEmpty(String s) {
+        return s == null || s.length() == 0;
     }
-    return result;
 
-  }
-
-  public static Set<Method> getMethodsFromDescriptors(Iterable<String> annotatedWith, ClassLoader... classLoaders) {
-    return getMethodsFromDescriptors(annotatedWith, Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
-  }
-
-  public static Set<Constructor> getConstructorsFromDescriptors(Iterable<String> annotatedWith, Optional<ClassLoader[]> classLoaders) {
-    Set<Constructor> result = new HashSet();
-    for (String annotated : annotatedWith) {
-      if (isConstructor(annotated)) {
-        Constructor member = (Constructor) getMemberFromDescriptor(annotated, classLoaders);
-        if (member != null)
-          result.add(member);
-      }
+    public static boolean isEmpty(Object[] objects) {
+        return objects == null || objects.length == 0;
     }
-    return result;
-  }
 
-  public static Set<Constructor> getConstructorsFromDescriptors(Iterable<String> annotatedWith, ClassLoader... classLoaders) {
-    return getConstructorsFromDescriptors(annotatedWith, Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
-  }
-
-  public static Set<Member> getMembersFromDescriptors(Iterable<String> values, Optional<ClassLoader[]> classLoaders) {
-    Set<Member> result = new HashSet();
-    for (String value : values) {
-      try {
-        result.add(Utils.getMemberFromDescriptor(value, classLoaders));
-      } catch (ReflectionsException e) {
-        throw new ReflectionsException("Can't resolve member named " + value, e);
-      }
+    public static File prepareFile(String filename) {
+        File file = new File(filename);
+        File parent = file.getAbsoluteFile().getParentFile();
+        if (!parent.exists()) {
+            // noinspection ResultOfMethodCallIgnored
+            parent.mkdirs();
+        }
+        return file;
     }
-    return result;
-  }
 
-  public static Set<Member> getMembersFromDescriptors(Iterable<String> values, ClassLoader... classLoaders) {
-    return getMembersFromDescriptors(values, Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
-  }
-
-  public static Field getFieldFromString(String field, ClassLoader... classLoaders) {
-    return getFieldFromString(field, Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
-  }
-
-  public static Field getFieldFromString(String field, Optional<ClassLoader[]> classLoaders) {
-    String className = field.substring(0, field.lastIndexOf('.'));
-    String fieldName = field.substring(field.lastIndexOf('.') + 1);
-
-    try {
-      return forName(className, classLoaders).getDeclaredField(fieldName);
-    } catch (NoSuchFieldException e) {
-      throw new ReflectionsException("Can't resolve field named " + fieldName, e);
+    public static Member getMemberFromDescriptor(String descriptor, ClassLoader... classLoaders) {
+        return getMemberFromDescriptor(descriptor,
+                Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
     }
-  }
 
-  public static void close(InputStream closeable) {
-    try {
-      if (closeable != null)
-        closeable.close();
-    } catch (IOException e) {
-      if (Reflections.log.isPresent()) {
-        Reflections.log.get().warn("Could not close InputStream", e);
-      }
+    public static Member getMemberFromDescriptor(String descriptor, Optional<ClassLoader[]> classLoaders) {
+        int p0 = descriptor.lastIndexOf('(');
+        String memberKey = p0 != -1 ? descriptor.substring(0, p0) : descriptor;
+        String methodParameters = p0 != -1 ? descriptor.substring(p0 + 1, descriptor.lastIndexOf(')')) : "";
+
+        int p1 = Math.max(memberKey.lastIndexOf('.'), memberKey.lastIndexOf('$'));
+        String className = memberKey.substring(memberKey.lastIndexOf(' ') + 1, p1);
+        int endsWithLambda = memberKey.lastIndexOf(".lambda");
+        if (endsWithLambda > -1) {
+            className = className.substring(0, endsWithLambda);
+        }
+        String memberName = memberKey.substring(p1 + 1);
+
+        Class<?>[] parameterTypes = getParameterTypes(classLoaders, methodParameters);
+
+        Class<?> aClass = forName(className, classLoaders);
+        return getMemberMethod(descriptor, className, endsWithLambda, memberName, parameterTypes, aClass);
     }
-  }
 
-  public static Optional<Logger> findLogger(Class<?> aClass) {
-    try {
-      // This is to check whether an optional SLF4J binding is available. While SLF4J recommends that libraries
-      // "should not declare a dependency on any SLF4J binding but only depend on slf4j-api", doing so forces
-      // users of the library to either add a binding to the classpath (even if just slf4j-nop) or to set the
-      // "slf4j.suppressInitError" system property in order to avoid the warning, which both is inconvenient.
-      Class.forName("org.slf4j.impl.StaticLoggerBinder");
-      return Optional.of(LoggerFactory.getLogger(aClass));
-    } catch (Throwable e) {
-      return Optional.empty();
+    private static Member getMemberMethod(String descriptor, String className, int endsWithLambda, String memberName,
+            Class<?>[] parameterTypes, Class<?> aClass) {
+        while (aClass != null) {
+            try {
+                if (!descriptor.contains("(")) {
+                    return aClass.isInterface() ? aClass.getField(memberName) : aClass.getDeclaredField(memberName);
+                } else if (isConstructor(descriptor)) {
+                    return aClass.isInterface() ? aClass.getConstructor(parameterTypes)
+                            : aClass.getDeclaredConstructor(parameterTypes);
+                } else if (endsWithLambda == -1) {
+                    return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes)
+                            : aClass.getDeclaredMethod(memberName, parameterTypes);
+                } else {
+                    memberName = new StringBuilder("lambda$").append(memberName).toString();
+                    return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes)
+                            : aClass.getDeclaredMethod(memberName, parameterTypes);
+                }
+            } catch (Exception e) {
+                aClass = aClass.getSuperclass();
+            }
+        }
+        throw new ReflectionsException("Can't resolve member named " + memberName + " for class " + className);
     }
-  }
 
-  public static boolean isConstructor(String fqn) {
-    return fqn.contains("init>");
-  }
-
-  public static String name(Class type) {
-    if (!type.isArray()) {
-      return type.getName();
-    } else {
-      int dim = 0;
-      while (type.isArray()) {
-        dim++;
-        type = type.getComponentType();
-      }
-      return type.getName() + repeat("[]", dim);
+    private static Class<?>[] getParameterTypes(Optional<ClassLoader[]> classLoaders, String methodParameters) {
+        Class<?>[] parameterTypes = null;
+        if (!isEmpty(methodParameters)) {
+            String[] parameterNames = methodParameters.split(",");
+            List<Class<?>> result = new ArrayList<>(parameterNames.length);
+            for (String name : parameterNames) {
+                result.add(forName(name.trim(), classLoaders));
+            }
+            parameterTypes = result.toArray(new Class<?>[result.size()]);
+        }
+        return parameterTypes;
     }
-  }
 
-  public static List<String> names(Iterable<Class<?>> types) {
-    List<String> result = new ArrayList<String>();
-    for (Class<?> type : types)
-      result.add(name(type));
-    return result;
-  }
+    public static Set<Method> getMethodsFromDescriptors(Iterable<String> annotatedWith,
+            Optional<ClassLoader[]> classLoaders) {
+        Set<Method> result = new HashSet<>();
+        for (String annotated : annotatedWith) {
+            if (!isConstructor(annotated)) {
+                Method member = (Method) getMemberFromDescriptor(annotated, classLoaders);
+                if (member != null)
+                    result.add(member);
+            }
+        }
+        return result;
 
-  public static List<String> names(Class<?>... types) {
-    return names(Arrays.asList(types));
-  }
+    }
 
-  public static String name(Constructor constructor) {
-    return constructor.getName() + "." + "<init>" + "(" + Joiner.on(", ").join(names(constructor.getParameterTypes())) + ")";
-  }
+    public static Set<Method> getMethodsFromDescriptors(Iterable<String> annotatedWith, ClassLoader... classLoaders) {
+        return getMethodsFromDescriptors(annotatedWith,
+                Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
+    }
 
-  public static String name(Method method) {
-    return method.getDeclaringClass().getName() + "." + method.getName() + "(" + Joiner.on(", ").join(names(method.getParameterTypes()))
-        + ")";
-  }
+    public static Set<Constructor> getConstructorsFromDescriptors(Iterable<String> annotatedWith,
+            Optional<ClassLoader[]> classLoaders) {
+        Set<Constructor> result = new HashSet();
+        for (String annotated : annotatedWith) {
+            if (isConstructor(annotated)) {
+                Constructor member = (Constructor) getMemberFromDescriptor(annotated, classLoaders);
+                if (member != null)
+                    result.add(member);
+            }
+        }
+        return result;
+    }
 
-  public static String name(Field field) {
-    return field.getDeclaringClass().getName() + "." + field.getName();
-  }
+    public static Set<Constructor> getConstructorsFromDescriptors(Iterable<String> annotatedWith,
+            ClassLoader... classLoaders) {
+        return getConstructorsFromDescriptors(annotatedWith,
+                Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
+    }
 
-  public static String index(Class<? extends Scanner> scannerClass) {
-    return scannerClass.getSimpleName();
-  }
+    public static Set<Member> getMembersFromDescriptors(Iterable<String> values, Optional<ClassLoader[]> classLoaders) {
+        Set<Member> result = new HashSet();
+        for (String value : values) {
+            try {
+                result.add(Utils.getMemberFromDescriptor(value, classLoaders));
+            } catch (ReflectionsException e) {
+                throw new ReflectionsException("Can't resolve member named " + value, e);
+            }
+        }
+        return result;
+    }
+
+    public static Set<Member> getMembersFromDescriptors(Iterable<String> values, ClassLoader... classLoaders) {
+        return getMembersFromDescriptors(values,
+                Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
+    }
+
+    public static Field getFieldFromString(String field, ClassLoader... classLoaders) {
+        return getFieldFromString(field, Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
+    }
+
+    public static Field getFieldFromString(String field, Optional<ClassLoader[]> classLoaders) {
+        String className = field.substring(0, field.lastIndexOf('.'));
+        String fieldName = field.substring(field.lastIndexOf('.') + 1);
+
+        try {
+            return forName(className, classLoaders).getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            throw new ReflectionsException("Can't resolve field named " + fieldName, e);
+        }
+    }
+
+    public static void close(InputStream closeable) {
+        try {
+            if (closeable != null)
+                closeable.close();
+        } catch (IOException e) {
+            if (Reflections.log.isPresent()) {
+                Reflections.log.get().warn("Could not close InputStream", e);
+            }
+        }
+    }
+
+    public static Optional<Logger> findLogger(Class<?> aClass) {
+        try {
+            // This is to check whether an optional SLF4J binding is available. While SLF4J
+            // recommends that libraries
+            // "should not declare a dependency on any SLF4J binding but only depend on
+            // slf4j-api", doing so forces
+            // users of the library to either add a binding to the classpath (even if just
+            // slf4j-nop) or to set the
+            // "slf4j.suppressInitError" system property in order to avoid the warning,
+            // which both is inconvenient.
+            Class.forName("org.slf4j.impl.StaticLoggerBinder");
+            return Optional.of(LoggerFactory.getLogger(aClass));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    public static boolean isConstructor(String fqn) {
+        return fqn.contains("init>");
+    }
+
+    public static String name(Class type) {
+        if (!type.isArray()) {
+            return type.getName();
+        } else {
+            int dim = 0;
+            while (type.isArray()) {
+                dim++;
+                type = type.getComponentType();
+            }
+            return type.getName() + repeat("[]", dim);
+        }
+    }
+
+    public static List<String> names(Iterable<Class<?>> types) {
+        List<String> result = new ArrayList<>();
+        for (Class<?> type : types)
+            result.add(name(type));
+        return result;
+    }
+
+    public static List<String> names(Class<?>... types) {
+        return names(Arrays.asList(types));
+    }
+
+    public static String name(Constructor constructor) {
+        return constructor.getName() + "." + "<init>" + "("
+                + Joiner.on(", ").join(names(constructor.getParameterTypes())) + ")";
+    }
+
+    public static String name(Method method) {
+        return method.getDeclaringClass().getName() + "." + method.getName() + "("
+                + Joiner.on(", ").join(names(method.getParameterTypes())) + ")";
+    }
+
+    public static String name(Field field) {
+        return field.getDeclaringClass().getName() + "." + field.getName();
+    }
+
+    public static String index(Class<? extends Scanner> scannerClass) {
+        return scannerClass.getSimpleName();
+    }
 }

--- a/src/main/java/org/reflections8/util/Utils.java
+++ b/src/main/java/org/reflections8/util/Utils.java
@@ -74,8 +74,8 @@ public abstract class Utils {
 
         int p1 = Math.max(memberKey.lastIndexOf('.'), memberKey.lastIndexOf('$'));
         String className = memberKey.substring(memberKey.lastIndexOf(' ') + 1, p1);
-        int endsWithLambda = memberKey.lastIndexOf(".lambda");
-        if (endsWithLambda > -1) {
+        int endsWithLambda = className.lastIndexOf(".lambda");
+        if (endsWithLambda > 0) {
             className = className.substring(0, endsWithLambda);
         }
         String memberName = memberKey.substring(p1 + 1);

--- a/src/main/java/org/reflections8/util/Utils.java
+++ b/src/main/java/org/reflections8/util/Utils.java
@@ -1,5 +1,6 @@
 package org.reflections8.util;
 
+import static java.util.Optional.of;
 import static org.reflections8.ReflectionUtils.forName;
 
 import java.io.File;
@@ -63,8 +64,7 @@ public abstract class Utils {
     }
 
     public static Member getMemberFromDescriptor(String descriptor, ClassLoader... classLoaders) {
-        return getMemberFromDescriptor(descriptor,
-                Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
+        return getMemberFromDescriptor(descriptor, of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
     }
 
     public static Member getMemberFromDescriptor(String descriptor, Optional<ClassLoader[]> classLoaders) {
@@ -83,28 +83,7 @@ public abstract class Utils {
 
         Class<?>[] parameterTypes = getParameterTypes(classLoaders, methodParameters);
         Class<?> aClass = forName(className, classLoaders);
-        return getMember(descriptor, className, endsWithLambda, memberName, parameterTypes, aClass);
-    }
-
-    private static Member getMember(String descriptor, String className, int endsWithLambda, String memberName,
-            Class<?>[] parameterTypes, Class<?> aClass) {
-        while (aClass != null) {
-            try {
-                if (!descriptor.contains("(")) {
-                    return aClass.isInterface() ? aClass.getField(memberName) : aClass.getDeclaredField(memberName);
-                } else if (isConstructor(descriptor)) {
-                    return aClass.isInterface() ? aClass.getConstructor(parameterTypes)
-                            : aClass.getDeclaredConstructor(parameterTypes);
-                } else {
-                    return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes)
-                            : aClass.getDeclaredMethod(memberName, parameterTypes);
-
-                }
-            } catch (Exception e) {
-                aClass = aClass.getSuperclass();
-            }
-        }
-        throw new ReflectionsException("Can't resolve member named " + memberName + " for class " + className);
+        return getMember(descriptor, className, memberName, parameterTypes, aClass);
     }
 
     private static Class<?>[] getParameterTypes(Optional<ClassLoader[]> classLoaders, String methodParameters) {
@@ -118,6 +97,26 @@ public abstract class Utils {
             parameterTypes = result.toArray(new Class<?>[result.size()]);
         }
         return parameterTypes;
+    }
+
+    private static Member getMember(String descriptor, String className, String memberName, Class<?>[] parameterTypes,
+            Class<?> aClass) {
+        while (aClass != null) {
+            try {
+                if (!descriptor.contains("(")) {
+                    return aClass.isInterface() ? aClass.getField(memberName) : aClass.getDeclaredField(memberName);
+                } else if (isConstructor(descriptor)) {
+                    return aClass.isInterface() ? aClass.getConstructor(parameterTypes)
+                            : aClass.getDeclaredConstructor(parameterTypes);
+                } else {
+                    return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes)
+                            : aClass.getDeclaredMethod(memberName, parameterTypes);
+                }
+            } catch (Exception e) {
+                aClass = aClass.getSuperclass();
+            }
+        }
+        throw new ReflectionsException("Can't resolve member named " + memberName + " for class " + className);
     }
 
     public static Set<Method> getMethodsFromDescriptors(Iterable<String> annotatedWith,
@@ -135,13 +134,12 @@ public abstract class Utils {
     }
 
     public static Set<Method> getMethodsFromDescriptors(Iterable<String> annotatedWith, ClassLoader... classLoaders) {
-        return getMethodsFromDescriptors(annotatedWith,
-                Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
+        return getMethodsFromDescriptors(annotatedWith, of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
     }
 
     public static Set<Constructor> getConstructorsFromDescriptors(Iterable<String> annotatedWith,
             Optional<ClassLoader[]> classLoaders) {
-        Set<Constructor> result = new HashSet();
+        Set<Constructor> result = new HashSet<>();
         for (String annotated : annotatedWith) {
             if (isConstructor(annotated)) {
                 Constructor member = (Constructor) getMemberFromDescriptor(annotated, classLoaders);
@@ -159,7 +157,7 @@ public abstract class Utils {
     }
 
     public static Set<Member> getMembersFromDescriptors(Iterable<String> values, Optional<ClassLoader[]> classLoaders) {
-        Set<Member> result = new HashSet();
+        Set<Member> result = new HashSet<>();
         for (String value : values) {
             try {
                 result.add(Utils.getMemberFromDescriptor(value, classLoaders));
@@ -222,7 +220,7 @@ public abstract class Utils {
         return fqn.contains("init>");
     }
 
-    public static String name(Class type) {
+    public static String name(Class<?> type) {
         if (!type.isArray()) {
             return type.getName();
         } else {
@@ -246,7 +244,7 @@ public abstract class Utils {
         return names(Arrays.asList(types));
     }
 
-    public static String name(Constructor constructor) {
+    public static String name(Constructor<?> constructor) {
         return constructor.getName() + "." + "<init>" + "("
                 + Joiner.on(", ").join(names(constructor.getParameterTypes())) + ")";
     }

--- a/src/main/java/org/reflections8/util/Utils.java
+++ b/src/main/java/org/reflections8/util/Utils.java
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import org.reflections8.Reflections;
 import org.reflections8.ReflectionsException;
@@ -69,55 +68,39 @@ public abstract class Utils {
     }
 
     public static Member getMemberFromDescriptor(String descriptor, Optional<ClassLoader[]> classLoaders) {
-        System.out.println("---------------------------------------------------------------------------");
-        System.out.println("Descriptor: " + descriptor);
         int p0 = descriptor.lastIndexOf('(');
         String memberKey = p0 != -1 ? descriptor.substring(0, p0) : descriptor;
-        System.out.println("memberKey:" + memberKey);
         String methodParameters = p0 != -1 ? descriptor.substring(p0 + 1, descriptor.lastIndexOf(')')) : "";
 
         int p1 = Math.max(memberKey.lastIndexOf('.'), memberKey.lastIndexOf('$'));
         String className = memberKey.substring(memberKey.lastIndexOf(' ') + 1, p1);
-        System.out.println("className:" + className);
         String memberName = memberKey.substring(p1 + 1);
-        System.out.println("memberName:" + memberName);
         int endsWithLambda = memberKey.lastIndexOf(".lambda");
         if (endsWithLambda > 0) {
-            memberName = memberKey.substring(endsWithLambda + 7);
+            memberName = memberKey.substring(endsWithLambda + 1);
             className = memberKey.substring(memberKey.lastIndexOf(' ') + 1, endsWithLambda);
         }
 
         Class<?>[] parameterTypes = getParameterTypes(classLoaders, methodParameters);
-        System.out.println("Classname: " + className);
         Class<?> aClass = forName(className, classLoaders);
-        System.out.println("Class: " + aClass.toString());
         return getMember(descriptor, className, endsWithLambda, memberName, parameterTypes, aClass);
     }
 
     private static Member getMember(String descriptor, String className, int endsWithLambda, String memberName,
             Class<?>[] parameterTypes, Class<?> aClass) {
         while (aClass != null) {
-            System.out.println("aClass: " + aClass);
             try {
                 if (!descriptor.contains("(")) {
                     return aClass.isInterface() ? aClass.getField(memberName) : aClass.getDeclaredField(memberName);
                 } else if (isConstructor(descriptor)) {
                     return aClass.isInterface() ? aClass.getConstructor(parameterTypes)
                             : aClass.getDeclaredConstructor(parameterTypes);
-                } else if (endsWithLambda == -1) {
-                    return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes)
-                            : aClass.getDeclaredMethod(memberName, parameterTypes);
                 } else {
-                    System.out.println("MemberName 1:" + memberName);
-                    memberName = new StringBuilder("lambda").append(memberName).toString();
-                    System.out.println("............................");
-                    Stream.of(aClass.getDeclaredMethods()).forEach(System.out::println);
-                    System.out.println("............................");
                     return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes)
                             : aClass.getDeclaredMethod(memberName, parameterTypes);
+
                 }
             } catch (Exception e) {
-                System.out.println("Exception:" + e.getMessage());
                 aClass = aClass.getSuperclass();
             }
         }

--- a/src/main/java/org/reflections8/util/Utils.java
+++ b/src/main/java/org/reflections8/util/Utils.java
@@ -27,199 +27,214 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class Utils {
 
-    public static String repeat(String string, int times) {
-        StringBuilder sb = new StringBuilder();
+  public static String repeat(String string, int times) {
+    StringBuilder sb = new StringBuilder();
 
-        for (int i = 0; i < times; i++) {
-            sb.append(string);
-        }
-
-        return sb.toString();
+    for (int i = 0; i < times; i++) {
+      sb.append(string);
     }
 
-    /**
-     * isEmpty compatible with Java 5
-     */
-    public static boolean isEmpty(String s) {
-        return s == null || s.length() == 0;
+    return sb.toString();
+  }
+
+  /**
+   * isEmpty compatible with Java 5
+   */
+  public static boolean isEmpty(String s) {
+    return s == null || s.length() == 0;
+  }
+
+  public static boolean isEmpty(Object[] objects) {
+    return objects == null || objects.length == 0;
+  }
+
+  public static File prepareFile(String filename) {
+    File file = new File(filename);
+    File parent = file.getAbsoluteFile().getParentFile();
+    if (!parent.exists()) {
+      //noinspection ResultOfMethodCallIgnored
+      parent.mkdirs();
+    }
+    return file;
+  }
+
+  public static Member getMemberFromDescriptor(String descriptor, ClassLoader... classLoaders) throws ReflectionsException {
+    return getMemberFromDescriptor(descriptor, Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
+  }
+
+  public static Member getMemberFromDescriptor(String descriptor, Optional<ClassLoader[]> classLoaders) throws ReflectionsException {
+    int p0 = descriptor.lastIndexOf('(');
+    String memberKey = p0 != -1 ? descriptor.substring(0, p0) : descriptor;
+    String methodParameters = p0 != -1 ? descriptor.substring(p0 + 1, descriptor.lastIndexOf(')')) : "";
+
+    int p1 = Math.max(memberKey.lastIndexOf('.'), memberKey.lastIndexOf("$"));
+    String className = memberKey.substring(memberKey.lastIndexOf(' ') + 1, p1);
+    int endsWithLambda = memberKey.lastIndexOf(".lambda");
+    if (endsWithLambda > -1) {
+      className = className.substring(0, endsWithLambda);
+    }
+    String memberName = memberKey.substring(p1 + 1);
+
+    Class<?>[] parameterTypes = null;
+    if (!isEmpty(methodParameters)) {
+      String[] parameterNames = methodParameters.split(",");
+      List<Class<?>> result = new ArrayList<Class<?>>(parameterNames.length);
+      for (String name : parameterNames) {
+        result.add(forName(name.trim(), classLoaders));
+      }
+      parameterTypes = result.toArray(new Class<?>[result.size()]);
     }
 
-    public static boolean isEmpty(Object[] objects) {
-        return objects == null || objects.length == 0;
-    }
-
-    public static File prepareFile(String filename) {
-        File file = new File(filename);
-        File parent = file.getAbsoluteFile().getParentFile();
-        if (!parent.exists()) {
-            //noinspection ResultOfMethodCallIgnored
-            parent.mkdirs();
-        }
-        return file;
-    }
-
-    public static Member getMemberFromDescriptor(String descriptor, ClassLoader... classLoaders) throws ReflectionsException {
-        return getMemberFromDescriptor(descriptor, Optional.of(classLoaders != null? classLoaders : new ClassLoader[]{}));
-    }
-
-    public static Member getMemberFromDescriptor(String descriptor, Optional<ClassLoader[]> classLoaders) throws ReflectionsException {
-        int p0 = descriptor.lastIndexOf('(');
-        String memberKey = p0 != -1 ? descriptor.substring(0, p0) : descriptor;
-        String methodParameters = p0 != -1 ? descriptor.substring(p0 + 1, descriptor.lastIndexOf(')')) : "";
-
-        int p1 = Math.max(memberKey.lastIndexOf('.'), memberKey.lastIndexOf("$"));
-        String className = memberKey.substring(memberKey.lastIndexOf(' ') + 1, p1);
-        String memberName = memberKey.substring(p1 + 1);
-
-        Class<?>[] parameterTypes = null;
-        if (!isEmpty(methodParameters)) {
-            String[] parameterNames = methodParameters.split(",");
-            List<Class<?>> result = new ArrayList<Class<?>>(parameterNames.length);
-            for (String name : parameterNames) {
-                result.add(forName(name.trim(), classLoaders));
-            }
-            parameterTypes = result.toArray(new Class<?>[result.size()]);
-        }
-
-        Class<?> aClass = forName(className, classLoaders);
-        while (aClass != null) {
-            try {
-                if (!descriptor.contains("(")) {
-                    return aClass.isInterface() ? aClass.getField(memberName) : aClass.getDeclaredField(memberName);
-                } else if (isConstructor(descriptor)) {
-                    return aClass.isInterface() ? aClass.getConstructor(parameterTypes) : aClass.getDeclaredConstructor(parameterTypes);
-                } else {
-                    return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes) : aClass.getDeclaredMethod(memberName, parameterTypes);
-                }
-            } catch (Exception e) {
-                aClass = aClass.getSuperclass();
-            }
-        }
-        throw new ReflectionsException("Can't resolve member named " + memberName + " for class " + className);
-    }
-
-    public static Set<Method> getMethodsFromDescriptors(Iterable<String> annotatedWith, Optional<ClassLoader[]> classLoaders) {
-        Set<Method> result = new HashSet();
-        for (String annotated : annotatedWith) {
-            if (!isConstructor(annotated)) {
-                Method member = (Method) getMemberFromDescriptor(annotated, classLoaders);
-                if (member != null) result.add(member);
-            }
-        }
-        return result;
-
-    }
-    public static Set<Method> getMethodsFromDescriptors(Iterable<String> annotatedWith, ClassLoader... classLoaders) {
-        return getMethodsFromDescriptors(annotatedWith, Optional.of(classLoaders != null? classLoaders : new ClassLoader[]{}));
-    }
-
-    public static Set<Constructor> getConstructorsFromDescriptors(Iterable<String> annotatedWith, Optional<ClassLoader[]> classLoaders) {
-        Set<Constructor> result = new HashSet();
-        for (String annotated : annotatedWith) {
-            if (isConstructor(annotated)) {
-                Constructor member = (Constructor) getMemberFromDescriptor(annotated, classLoaders);
-                if (member != null) result.add(member);
-            }
-        }
-        return result;
-    }
-    public static Set<Constructor> getConstructorsFromDescriptors(Iterable<String> annotatedWith, ClassLoader... classLoaders) {
-        return getConstructorsFromDescriptors(annotatedWith, Optional.of(classLoaders != null? classLoaders : new ClassLoader[]{}));
-    }
-
-    public static Set<Member> getMembersFromDescriptors(Iterable<String> values, Optional<ClassLoader[]> classLoaders) {
-        Set<Member> result = new HashSet();
-        for (String value : values) {
-            try {
-                result.add(Utils.getMemberFromDescriptor(value, classLoaders));
-            } catch (ReflectionsException e) {
-                throw new ReflectionsException("Can't resolve member named " + value, e);
-            }
-        }
-        return result;
-    }
-
-    public static Set<Member> getMembersFromDescriptors(Iterable<String> values, ClassLoader... classLoaders) {
-        return getMembersFromDescriptors(values, Optional.of(classLoaders != null? classLoaders : new ClassLoader[]{}));
-    }
-
-    public static Field getFieldFromString(String field, ClassLoader... classLoaders) {
-        return getFieldFromString(field, Optional.of(classLoaders != null? classLoaders : new ClassLoader[]{}));
-    }
-
-
-    public static Field getFieldFromString(String field, Optional<ClassLoader[]> classLoaders) {
-        String className = field.substring(0, field.lastIndexOf('.'));
-        String fieldName = field.substring(field.lastIndexOf('.') + 1);
-
-        try {
-            return forName(className, classLoaders).getDeclaredField(fieldName);
-        } catch (NoSuchFieldException e) {
-            throw new ReflectionsException("Can't resolve field named " + fieldName, e);
-        }
-    }
-
-    public static void close(InputStream closeable) {
-        try { if (closeable != null) closeable.close(); }
-        catch (IOException e) {
-            if (Reflections.log.isPresent()) {
-                Reflections.log.get().warn("Could not close InputStream", e);
-            }
-        }
-    }
-
-    public static Optional<Logger> findLogger(Class<?> aClass) {
-        try {
-            // This is to check whether an optional SLF4J binding is available. While SLF4J recommends that libraries
-            // "should not declare a dependency on any SLF4J binding but only depend on slf4j-api", doing so forces
-            // users of the library to either add a binding to the classpath (even if just slf4j-nop) or to set the
-            // "slf4j.suppressInitError" system property in order to avoid the warning, which both is inconvenient.
-            Class.forName("org.slf4j.impl.StaticLoggerBinder");
-            return Optional.of(LoggerFactory.getLogger(aClass));
-        } catch (Throwable e) {
-            return Optional.empty();
-        }
-    }
-
-    public static boolean isConstructor(String fqn) {
-        return fqn.contains("init>");
-    }
-
-    public static String name(Class type) {
-        if (!type.isArray()) {
-            return type.getName();
+    Class<?> aClass = forName(className, classLoaders);
+    while (aClass != null) {
+      try {
+        if (!descriptor.contains("(")) {
+          return aClass.isInterface() ? aClass.getField(memberName) : aClass.getDeclaredField(memberName);
+        } else if (isConstructor(descriptor)) {
+          return aClass.isInterface() ? aClass.getConstructor(parameterTypes) : aClass.getDeclaredConstructor(parameterTypes);
+        } else if (endsWithLambda == -1) {
+          return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes) : aClass.getDeclaredMethod(memberName, parameterTypes);
         } else {
-            int dim = 0;
-            while (type.isArray()) {
-                dim++;
-                type = type.getComponentType();
-            }
-            return type.getName() + repeat("[]", dim);
+          memberName = new StringBuilder("lambda$").append(memberName).toString();
+          return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes) : aClass.getDeclaredMethod(memberName, parameterTypes);
         }
+      } catch (Exception e) {
+        aClass = aClass.getSuperclass();
+      }
     }
+    throw new ReflectionsException("Can't resolve member named " + memberName + " for class " + className);
+  }
 
-
-    public static List<String> names(Iterable<Class<?>> types) {
-        List<String> result = new ArrayList<String>();
-        for (Class<?> type : types) result.add(name(type));
-        return result;
+  public static Set<Method> getMethodsFromDescriptors(Iterable<String> annotatedWith, Optional<ClassLoader[]> classLoaders) {
+    Set<Method> result = new HashSet();
+    for (String annotated : annotatedWith) {
+      if (!isConstructor(annotated)) {
+        Method member = (Method) getMemberFromDescriptor(annotated, classLoaders);
+        if (member != null)
+          result.add(member);
+      }
     }
+    return result;
 
-    public static List<String> names(Class<?>... types) {
-        return names(Arrays.asList(types));
+  }
+
+  public static Set<Method> getMethodsFromDescriptors(Iterable<String> annotatedWith, ClassLoader... classLoaders) {
+    return getMethodsFromDescriptors(annotatedWith, Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
+  }
+
+  public static Set<Constructor> getConstructorsFromDescriptors(Iterable<String> annotatedWith, Optional<ClassLoader[]> classLoaders) {
+    Set<Constructor> result = new HashSet();
+    for (String annotated : annotatedWith) {
+      if (isConstructor(annotated)) {
+        Constructor member = (Constructor) getMemberFromDescriptor(annotated, classLoaders);
+        if (member != null)
+          result.add(member);
+      }
     }
+    return result;
+  }
 
-    public static String name(Constructor constructor) {
-        return constructor.getName() + "." + "<init>" + "(" + Joiner.on(", ").join(names(constructor.getParameterTypes())) + ")";
+  public static Set<Constructor> getConstructorsFromDescriptors(Iterable<String> annotatedWith, ClassLoader... classLoaders) {
+    return getConstructorsFromDescriptors(annotatedWith, Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
+  }
+
+  public static Set<Member> getMembersFromDescriptors(Iterable<String> values, Optional<ClassLoader[]> classLoaders) {
+    Set<Member> result = new HashSet();
+    for (String value : values) {
+      try {
+        result.add(Utils.getMemberFromDescriptor(value, classLoaders));
+      } catch (ReflectionsException e) {
+        throw new ReflectionsException("Can't resolve member named " + value, e);
+      }
     }
+    return result;
+  }
 
-    public static String name(Method method) {
-        return method.getDeclaringClass().getName() + "." + method.getName() + "(" + Joiner.on(", ").join(names(method.getParameterTypes())) + ")";
+  public static Set<Member> getMembersFromDescriptors(Iterable<String> values, ClassLoader... classLoaders) {
+    return getMembersFromDescriptors(values, Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
+  }
+
+  public static Field getFieldFromString(String field, ClassLoader... classLoaders) {
+    return getFieldFromString(field, Optional.of(classLoaders != null ? classLoaders : new ClassLoader[] {}));
+  }
+
+  public static Field getFieldFromString(String field, Optional<ClassLoader[]> classLoaders) {
+    String className = field.substring(0, field.lastIndexOf('.'));
+    String fieldName = field.substring(field.lastIndexOf('.') + 1);
+
+    try {
+      return forName(className, classLoaders).getDeclaredField(fieldName);
+    } catch (NoSuchFieldException e) {
+      throw new ReflectionsException("Can't resolve field named " + fieldName, e);
     }
+  }
 
-    public static String name(Field field) {
-        return field.getDeclaringClass().getName() + "." + field.getName();
+  public static void close(InputStream closeable) {
+    try {
+      if (closeable != null)
+        closeable.close();
+    } catch (IOException e) {
+      if (Reflections.log.isPresent()) {
+        Reflections.log.get().warn("Could not close InputStream", e);
+      }
     }
+  }
 
-    public static String index(Class<? extends Scanner> scannerClass) { return scannerClass.getSimpleName(); }
+  public static Optional<Logger> findLogger(Class<?> aClass) {
+    try {
+      // This is to check whether an optional SLF4J binding is available. While SLF4J recommends that libraries
+      // "should not declare a dependency on any SLF4J binding but only depend on slf4j-api", doing so forces
+      // users of the library to either add a binding to the classpath (even if just slf4j-nop) or to set the
+      // "slf4j.suppressInitError" system property in order to avoid the warning, which both is inconvenient.
+      Class.forName("org.slf4j.impl.StaticLoggerBinder");
+      return Optional.of(LoggerFactory.getLogger(aClass));
+    } catch (Throwable e) {
+      return Optional.empty();
+    }
+  }
+
+  public static boolean isConstructor(String fqn) {
+    return fqn.contains("init>");
+  }
+
+  public static String name(Class type) {
+    if (!type.isArray()) {
+      return type.getName();
+    } else {
+      int dim = 0;
+      while (type.isArray()) {
+        dim++;
+        type = type.getComponentType();
+      }
+      return type.getName() + repeat("[]", dim);
+    }
+  }
+
+  public static List<String> names(Iterable<Class<?>> types) {
+    List<String> result = new ArrayList<String>();
+    for (Class<?> type : types)
+      result.add(name(type));
+    return result;
+  }
+
+  public static List<String> names(Class<?>... types) {
+    return names(Arrays.asList(types));
+  }
+
+  public static String name(Constructor constructor) {
+    return constructor.getName() + "." + "<init>" + "(" + Joiner.on(", ").join(names(constructor.getParameterTypes())) + ")";
+  }
+
+  public static String name(Method method) {
+    return method.getDeclaringClass().getName() + "." + method.getName() + "(" + Joiner.on(", ").join(names(method.getParameterTypes()))
+        + ")";
+  }
+
+  public static String name(Field field) {
+    return field.getDeclaringClass().getName() + "." + field.getName();
+  }
+
+  public static String index(Class<? extends Scanner> scannerClass) {
+    return scannerClass.getSimpleName();
+  }
 }

--- a/src/test/java/org/reflections8/MyTestModelStore.java
+++ b/src/test/java/org/reflections8/MyTestModelStore.java
@@ -1,4 +1,4 @@
-//generated using Reflections JavaCodeSerializer [Thu Oct 24 14:38:48 CEST 2019]
+//generated using Reflections JavaCodeSerializer [Fri Oct 25 09:23:24 CEST 2019]
 package org.reflections8;
 
 public interface MyTestModelStore {

--- a/src/test/java/org/reflections8/MyTestModelStore.java
+++ b/src/test/java/org/reflections8/MyTestModelStore.java
@@ -1,4 +1,4 @@
-//generated using Reflections JavaCodeSerializer [Thu Mar 14 08:45:41 CET 2019]
+//generated using Reflections JavaCodeSerializer [Thu Oct 24 14:38:48 CEST 2019]
 package org.reflections8;
 
 public interface MyTestModelStore {
@@ -97,6 +97,12 @@ public interface MyTestModelStore {
 			public interface TestModel$C7 {
 				public interface annotations {
 					public interface org_reflections8_TestModel$AC3 {}
+				}
+			}
+			public interface TestModel$C8 {
+				public interface methods {
+					public interface lambda$print$0 {}
+					public interface print {}
 				}
 			}
 			public interface TestModel$I1 {

--- a/src/test/java/org/reflections8/MyTestModelStore.java
+++ b/src/test/java/org/reflections8/MyTestModelStore.java
@@ -1,4 +1,4 @@
-//generated using Reflections JavaCodeSerializer [Fri Oct 25 09:23:24 CEST 2019]
+//generated using Reflections JavaCodeSerializer [Fri Oct 25 09:27:30 CEST 2019]
 package org.reflections8;
 
 public interface MyTestModelStore {

--- a/src/test/java/org/reflections8/MyTestModelStore.java
+++ b/src/test/java/org/reflections8/MyTestModelStore.java
@@ -1,4 +1,4 @@
-//generated using Reflections JavaCodeSerializer [Fri Oct 25 09:27:30 CEST 2019]
+//generated using Reflections JavaCodeSerializer [Fri Oct 25 09:49:16 CEST 2019]
 package org.reflections8;
 
 public interface MyTestModelStore {

--- a/src/test/java/org/reflections8/ReflectionsTest.java
+++ b/src/test/java/org/reflections8/ReflectionsTest.java
@@ -215,7 +215,7 @@ public class ReflectionsTest {
                     are(C4.class.getDeclaredMethod("m1"), C4.class.getDeclaredMethod("m3"),
                             AC2.class.getMethod("value"), AF1.class.getMethod("value"), AM1.class.getMethod("value"),
                             Usage.C1.class.getDeclaredMethod("method"), Usage.C2.class.getDeclaredMethod("method"),
-                            C8.class.getDeclaredMethod("print"), C8.class.getDeclaredMethod("lambda$0")));
+                            C8.class.getDeclaredMethod("print"), C8.class.getDeclaredMethod("lambda$print$0")));
 
             assertThat(reflections8.getMethodsMatchParams(int[][].class, String[][].class),
                     are(C4.class.getDeclaredMethod("m1", int[][].class, String[][].class)));
@@ -233,7 +233,7 @@ public class ReflectionsTest {
                             Usage.C1.class.getDeclaredMethod("method"),
                             Usage.C1.class.getDeclaredMethod("method", String.class),
                             Usage.C2.class.getDeclaredMethod("method"), C8.class.getDeclaredMethod("print"),
-                            C8.class.getDeclaredMethod("lambda$0")));
+                            C8.class.getDeclaredMethod("lambda$print$0")));
 
             assertThat(reflections8.getMethodsWithAnyParamAnnotated(AM1.class),
                     are(C4.class.getDeclaredMethod("m4", String.class)));

--- a/src/test/java/org/reflections8/ReflectionsTest.java
+++ b/src/test/java/org/reflections8/ReflectionsTest.java
@@ -5,26 +5,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.reflections8.TestModel.AC1;
-import static org.reflections8.TestModel.AC1n;
-import static org.reflections8.TestModel.AC2;
-import static org.reflections8.TestModel.AC3;
-import static org.reflections8.TestModel.AF1;
-import static org.reflections8.TestModel.AI1;
-import static org.reflections8.TestModel.AI2;
-import static org.reflections8.TestModel.AM1;
-import static org.reflections8.TestModel.C1;
-import static org.reflections8.TestModel.C2;
-import static org.reflections8.TestModel.C3;
-import static org.reflections8.TestModel.C4;
-import static org.reflections8.TestModel.C5;
-import static org.reflections8.TestModel.C6;
-import static org.reflections8.TestModel.C7;
-import static org.reflections8.TestModel.I1;
-import static org.reflections8.TestModel.I2;
-import static org.reflections8.TestModel.I3;
-import static org.reflections8.TestModel.MAI1;
-import static org.reflections8.TestModel.Usage;
 import static org.reflections8.util.Utils.index;
 
 import java.io.File;
@@ -44,6 +24,27 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.reflections8.TestModel.AC1;
+import org.reflections8.TestModel.AC1n;
+import org.reflections8.TestModel.AC2;
+import org.reflections8.TestModel.AC3;
+import org.reflections8.TestModel.AF1;
+import org.reflections8.TestModel.AI1;
+import org.reflections8.TestModel.AI2;
+import org.reflections8.TestModel.AM1;
+import org.reflections8.TestModel.C1;
+import org.reflections8.TestModel.C2;
+import org.reflections8.TestModel.C3;
+import org.reflections8.TestModel.C4;
+import org.reflections8.TestModel.C5;
+import org.reflections8.TestModel.C6;
+import org.reflections8.TestModel.C7;
+import org.reflections8.TestModel.C8;
+import org.reflections8.TestModel.I1;
+import org.reflections8.TestModel.I2;
+import org.reflections8.TestModel.I3;
+import org.reflections8.TestModel.MAI1;
+import org.reflections8.TestModel.Usage;
 import org.reflections8.scanners.FieldAnnotationsScanner;
 import org.reflections8.scanners.MemberUsageScanner;
 import org.reflections8.scanners.MethodAnnotationsScanner;
@@ -68,15 +69,9 @@ public class ReflectionsTest {
     @BeforeClass
     public static void init() {
         reflections8 = new Reflections(new ConfigurationBuilder()
-                .setUrls(asList(ClasspathHelper.forClass(TestModel.class)))
-                .filterInputsBy(TestModelFilter)
-                .setScanners(
-                        new SubTypesScanner(false),
-                        new TypeAnnotationsScanner(),
-                        new FieldAnnotationsScanner(),
-                        new MethodAnnotationsScanner(),
-                        new MethodParameterScanner(),
-                        new MethodParameterNamesScanner(),
+                .setUrls(asList(ClasspathHelper.forClass(TestModel.class))).filterInputsBy(TestModelFilter)
+                .setScanners(new SubTypesScanner(false), new TypeAnnotationsScanner(), new FieldAnnotationsScanner(),
+                        new MethodAnnotationsScanner(), new MethodParameterScanner(), new MethodParameterNamesScanner(),
                         new MemberUsageScanner()));
     }
 
@@ -103,23 +98,35 @@ public class ReflectionsTest {
         assertThat(reflections8.getTypesAnnotatedWith(AC1n.class, true), are(C1.class));
         assertThat(reflections8.getTypesAnnotatedWith(AC1n.class, true), annotatedWith(AC1n.class));
 
-        assertThat(reflections8.getTypesAnnotatedWith(MAI1.class), are(AI1.class, I1.class, I2.class, C1.class, C2.class, C3.class, C5.class));
+        assertThat(reflections8.getTypesAnnotatedWith(MAI1.class),
+                are(AI1.class, I1.class, I2.class, C1.class, C2.class, C3.class, C5.class));
         assertThat(reflections8.getTypesAnnotatedWith(MAI1.class), metaAnnotatedWith(MAI1.class));
 
-        assertThat(reflections8.getTypesAnnotatedWith(AI1.class), are(I1.class, I2.class, C1.class, C2.class, C3.class, C5.class));
+        assertThat(reflections8.getTypesAnnotatedWith(AI1.class),
+                are(I1.class, I2.class, C1.class, C2.class, C3.class, C5.class));
         assertThat(reflections8.getTypesAnnotatedWith(AI1.class), metaAnnotatedWith(AI1.class));
 
-        assertThat(reflections8.getTypesAnnotatedWith(AI2.class), are(I2.class, C1.class, C2.class, C3.class, C5.class));
+        assertThat(reflections8.getTypesAnnotatedWith(AI2.class),
+                are(I2.class, C1.class, C2.class, C3.class, C5.class));
         assertThat(reflections8.getTypesAnnotatedWith(AI2.class), metaAnnotatedWith(AI2.class));
 
         assertThat(reflections8.getTypesAnnotatedWith(AM1.class), isEmpty);
 
-        //annotation member value matching
+        // annotation member value matching
         AC2 ac2 = new AC2() {
-            public String value() {return "ugh?!";}
-            public Class<? extends Annotation> annotationType() {return AC2.class;}};
+            @Override
+            public String value() {
+                return "ugh?!";
+            }
 
-        assertThat(reflections8.getTypesAnnotatedWith(ac2), are(C3.class, C5.class, I3.class, C6.class, AC3.class, C7.class));
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return AC2.class;
+            }
+        };
+
+        assertThat(reflections8.getTypesAnnotatedWith(ac2),
+                are(C3.class, C5.class, I3.class, C6.class, AC3.class, C7.class));
 
         assertThat(reflections8.getTypesAnnotatedWith(ac2, true), are(C3.class, I3.class, AC3.class));
     }
@@ -128,19 +135,24 @@ public class ReflectionsTest {
     public void testMethodsAnnotatedWith() {
         try {
             assertThat(reflections8.getMethodsAnnotatedWith(AM1.class),
-                    are(C4.class.getDeclaredMethod("m1"),
-                        C4.class.getDeclaredMethod("m1", int.class, String[].class),
-                        C4.class.getDeclaredMethod("m1", int[][].class, String[][].class),
-                        C4.class.getDeclaredMethod("m3")));
+                    are(C4.class.getDeclaredMethod("m1"), C4.class.getDeclaredMethod("m1", int.class, String[].class),
+                            C4.class.getDeclaredMethod("m1", int[][].class, String[][].class),
+                            C4.class.getDeclaredMethod("m3")));
 
             AM1 am1 = new AM1() {
-                public String value() {return "1";}
-                public Class<? extends Annotation> annotationType() {return AM1.class;}
+                @Override
+                public String value() {
+                    return "1";
+                }
+
+                @Override
+                public Class<? extends Annotation> annotationType() {
+                    return AM1.class;
+                }
             };
             assertThat(reflections8.getMethodsAnnotatedWith(am1),
-                    are(C4.class.getDeclaredMethod("m1"),
-                        C4.class.getDeclaredMethod("m1", int.class, String[].class),
-                        C4.class.getDeclaredMethod("m1", int[][].class, String[][].class)));
+                    are(C4.class.getDeclaredMethod("m1"), C4.class.getDeclaredMethod("m1", int.class, String[].class),
+                            C4.class.getDeclaredMethod("m1", int[][].class, String[][].class)));
         } catch (NoSuchMethodException e) {
             fail();
         }
@@ -153,8 +165,15 @@ public class ReflectionsTest {
                     are(C4.class.getDeclaredConstructor(String.class)));
 
             AM1 am1 = new AM1() {
-                public String value() {return "1";}
-                public Class<? extends Annotation> annotationType() {return AM1.class;}
+                @Override
+                public String value() {
+                    return "1";
+                }
+
+                @Override
+                public Class<? extends Annotation> annotationType() {
+                    return AM1.class;
+                }
             };
             assertThat(reflections8.getConstructorsAnnotatedWith(am1),
                     are(C4.class.getDeclaredConstructor(String.class)));
@@ -167,14 +186,19 @@ public class ReflectionsTest {
     public void testFieldsAnnotatedWith() {
         try {
             assertThat(reflections8.getFieldsAnnotatedWith(AF1.class),
-                    are(C4.class.getDeclaredField("f1"),
-                        C4.class.getDeclaredField("f2")
-                        ));
+                    are(C4.class.getDeclaredField("f1"), C4.class.getDeclaredField("f2")));
 
             assertThat(reflections8.getFieldsAnnotatedWith(new AF1() {
-                            public String value() {return "2";}
-                            public Class<? extends Annotation> annotationType() {return AF1.class;}}),
-                    are(C4.class.getDeclaredField("f2")));
+                @Override
+                public String value() {
+                    return "2";
+                }
+
+                @Override
+                public Class<? extends Annotation> annotationType() {
+                    return AF1.class;
+                }
+            }), are(C4.class.getDeclaredField("f2")));
         } catch (NoSuchFieldException e) {
             fail();
         }
@@ -184,12 +208,14 @@ public class ReflectionsTest {
     public void testMethodParameter() {
         try {
             assertThat(reflections8.getMethodsMatchParams(String.class),
-                    are(C4.class.getDeclaredMethod("m4", String.class), Usage.C1.class.getDeclaredMethod("method", String.class)));
+                    are(C4.class.getDeclaredMethod("m4", String.class),
+                            Usage.C1.class.getDeclaredMethod("method", String.class)));
 
             assertThat(reflections8.getMethodsMatchParams(),
                     are(C4.class.getDeclaredMethod("m1"), C4.class.getDeclaredMethod("m3"),
                             AC2.class.getMethod("value"), AF1.class.getMethod("value"), AM1.class.getMethod("value"),
-                            Usage.C1.class.getDeclaredMethod("method"), Usage.C2.class.getDeclaredMethod("method")));
+                            Usage.C1.class.getDeclaredMethod("method"), Usage.C2.class.getDeclaredMethod("method"),
+                            C8.class.getDeclaredMethod("print"), C8.class.getDeclaredMethod("lambda$0")));
 
             assertThat(reflections8.getMethodsMatchParams(int[][].class, String[][].class),
                     are(C4.class.getDeclaredMethod("m1", int[][].class, String[][].class)));
@@ -203,18 +229,26 @@ public class ReflectionsTest {
 
             assertThat(reflections8.getMethodsReturn(void.class),
                     are(C4.class.getDeclaredMethod("m1"), C4.class.getDeclaredMethod("m1", int.class, String[].class),
-                            C4.class.getDeclaredMethod("m1", int[][].class, String[][].class), Usage.C1.class.getDeclaredMethod("method"),
-                            Usage.C1.class.getDeclaredMethod("method", String.class), Usage.C2.class.getDeclaredMethod("method")));
+                            C4.class.getDeclaredMethod("m1", int[][].class, String[][].class),
+                            Usage.C1.class.getDeclaredMethod("method"),
+                            Usage.C1.class.getDeclaredMethod("method", String.class),
+                            Usage.C2.class.getDeclaredMethod("method"), C8.class.getDeclaredMethod("print"),
+                            C8.class.getDeclaredMethod("lambda$0")));
 
             assertThat(reflections8.getMethodsWithAnyParamAnnotated(AM1.class),
                     are(C4.class.getDeclaredMethod("m4", String.class)));
 
-            assertThat(reflections8.getMethodsWithAnyParamAnnotated(
-                    new AM1() {
-                        public String value() { return "2"; }
-                        public Class<? extends Annotation> annotationType() { return AM1.class; }
-                    }),
-                    are(C4.class.getDeclaredMethod("m4", String.class)));
+            assertThat(reflections8.getMethodsWithAnyParamAnnotated(new AM1() {
+                @Override
+                public String value() {
+                    return "2";
+                }
+
+                @Override
+                public Class<? extends Annotation> annotationType() {
+                    return AM1.class;
+                }
+            }), are(C4.class.getDeclaredMethod("m4", String.class)));
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
@@ -226,28 +260,33 @@ public class ReflectionsTest {
                 are(C4.class.getDeclaredConstructor(String.class)));
 
         assertThat(reflections8.getConstructorsMatchParams(),
-                are(C1.class.getDeclaredConstructor(), C2.class.getDeclaredConstructor(), C3.class.getDeclaredConstructor(),
-                        C4.class.getDeclaredConstructor(), C5.class.getDeclaredConstructor(), C6.class.getDeclaredConstructor(),
-                        C7.class.getDeclaredConstructor(), Usage.C1.class.getDeclaredConstructor(), Usage.C2.class.getDeclaredConstructor()));
+                are(C1.class.getDeclaredConstructor(), C2.class.getDeclaredConstructor(),
+                        C3.class.getDeclaredConstructor(), C4.class.getDeclaredConstructor(),
+                        C5.class.getDeclaredConstructor(), C6.class.getDeclaredConstructor(),
+                        C7.class.getDeclaredConstructor(), Usage.C1.class.getDeclaredConstructor(),
+                        Usage.C2.class.getDeclaredConstructor(), C8.class.getDeclaredConstructor()));
 
         assertThat(reflections8.getConstructorsWithAnyParamAnnotated(AM1.class),
                 are(C4.class.getDeclaredConstructor(String.class)));
 
-        assertThat(reflections8.getConstructorsWithAnyParamAnnotated(
-                new AM1() {
-                    public String value() { return "1"; }
-                    public Class<? extends Annotation> annotationType() { return AM1.class; }
-                }),
-                are(C4.class.getDeclaredConstructor(String.class)));
+        assertThat(reflections8.getConstructorsWithAnyParamAnnotated(new AM1() {
+            @Override
+            public String value() {
+                return "1";
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return AM1.class;
+            }
+        }), are(C4.class.getDeclaredConstructor(String.class)));
     }
 
     @Test
     public void testResourcesScanner() {
         Predicate<String> filter = new FilterBuilder().include(".*\\.xml").exclude(".*testModel-reflections.*\\.xml");
-        Reflections localReflections8 = new Reflections(new ConfigurationBuilder()
-                .filterInputsBy(filter)
-                .setScanners(new ResourcesScanner())
-                .setUrls(asList(ClasspathHelper.forClass(TestModel.class))));
+        Reflections localReflections8 = new Reflections(new ConfigurationBuilder().filterInputsBy(filter)
+                .setScanners(new ResourcesScanner()).setUrls(asList(ClasspathHelper.forClass(TestModel.class))));
 
         Set<String> resolved = localReflections8.getResources(Pattern.compile(".*resource1-reflections\\.xml"));
         assertThat(resolved, are("META-INF/reflections/resource1-reflections.xml"));
@@ -258,8 +297,7 @@ public class ReflectionsTest {
 
     @Test
     public void testMethodParameterNames() throws NoSuchMethodException {
-        assertEquals(reflections8.getMethodParamNames(C4.class.getDeclaredMethod("m3")),
-                new ArrayList());
+        assertEquals(reflections8.getMethodParamNames(C4.class.getDeclaredMethod("m3")), new ArrayList());
 
         assertEquals(reflections8.getMethodParamNames(C4.class.getDeclaredMethod("m4", String.class)),
                 Arrays.asList("string"));
@@ -273,24 +311,22 @@ public class ReflectionsTest {
 
     @Test
     public void testMemberUsageScanner() throws NoSuchFieldException, NoSuchMethodException {
-        //field usage
+        // field usage
         assertThat(reflections8.getFieldUsage(Usage.C1.class.getDeclaredField("c2")),
-                are(Usage.C1.class.getDeclaredConstructor(),
-                        Usage.C1.class.getDeclaredConstructor(Usage.C2.class),
+                are(Usage.C1.class.getDeclaredConstructor(), Usage.C1.class.getDeclaredConstructor(Usage.C2.class),
                         Usage.C1.class.getDeclaredMethod("method"),
                         Usage.C1.class.getDeclaredMethod("method", String.class)));
 
-        //method usage
+        // method usage
         assertThat(reflections8.getMethodUsage(Usage.C1.class.getDeclaredMethod("method")),
                 are(Usage.C2.class.getDeclaredMethod("method")));
 
         assertThat(reflections8.getMethodUsage(Usage.C1.class.getDeclaredMethod("method", String.class)),
                 are(Usage.C2.class.getDeclaredMethod("method")));
 
-        //constructor usage
+        // constructor usage
         assertThat(reflections8.getConstructorUsage(Usage.C1.class.getDeclaredConstructor()),
-                are(Usage.C2.class.getDeclaredConstructor(),
-                        Usage.C2.class.getDeclaredMethod("method")));
+                are(Usage.C2.class.getDeclaredConstructor(), Usage.C2.class.getDeclaredMethod("method")));
 
         assertThat(reflections8.getConstructorUsage(Usage.C1.class.getDeclaredConstructor(Usage.C2.class)),
                 are(Usage.C2.class.getDeclaredMethod("method")));
@@ -302,14 +338,15 @@ public class ReflectionsTest {
             new Reflections(TestModel.class, TestModelFilter).getMethodsAnnotatedWith(AC1.class);
             fail();
         } catch (ReflectionsException e) {
-            assertEquals(e.getMessage(), "Scanner " + MethodAnnotationsScanner.class.getSimpleName() + " was not configured");
+            assertEquals(e.getMessage(),
+                    "Scanner " + MethodAnnotationsScanner.class.getSimpleName() + " was not configured");
         }
     }
 
     //
     public static String getUserDir() {
         File file = new File(System.getProperty("user.dir"));
-        //a hack to fix user.dir issue(?) in surfire
+        // a hack to fix user.dir issue(?) in surfire
         if (Arrays.asList(file.list()).contains("reflections")) {
             file = new File(file, "reflections");
         }
@@ -317,22 +354,27 @@ public class ReflectionsTest {
     }
 
     private final BaseMatcher<Set<Class<?>>> isEmpty = new BaseMatcher<Set<Class<?>>>() {
+        @Override
         public boolean matches(Object o) {
             return ((Collection<?>) o).isEmpty();
         }
 
+        @Override
         public void describeTo(Description description) {
             description.appendText("empty collection");
         }
     };
 
     private abstract static class Match<T> extends BaseMatcher<T> {
-        public void describeTo(Description description) { }
+        @Override
+        public void describeTo(Description description) {
+        }
     }
 
     public static <T> Matcher<Set<? super T>> are(final T... ts) {
         final Collection<?> c1 = Arrays.asList(ts);
         return new Match<Set<? super T>>() {
+            @Override
             public boolean matches(Object o) {
                 Collection<?> c2 = (Collection<?>) o;
                 return c1.containsAll(c2) && c2.containsAll(c1);
@@ -342,9 +384,11 @@ public class ReflectionsTest {
 
     private Matcher<Set<Class<?>>> annotatedWith(final Class<? extends Annotation> annotation) {
         return new Match<Set<Class<?>>>() {
+            @Override
             public boolean matches(Object o) {
                 for (Class<?> c : (Iterable<Class<?>>) o) {
-                    if (!ReflectionsIterables.contains(annotationTypes(Arrays.asList(c.getAnnotations())), annotation)) return false;
+                    if (!ReflectionsIterables.contains(annotationTypes(Arrays.asList(c.getAnnotations())), annotation))
+                        return false;
                 }
                 return true;
             }
@@ -353,6 +397,7 @@ public class ReflectionsTest {
 
     private Matcher<Set<Class<?>>> metaAnnotatedWith(final Class<? extends Annotation> annotation) {
         return new Match<Set<Class<?>>>() {
+            @Override
             public boolean matches(Object o) {
                 for (Class<?> c : (Iterable<Class<?>>) o) {
                     Set<Class> result = new HashSet();
@@ -361,12 +406,15 @@ public class ReflectionsTest {
                     while (!stack.isEmpty()) {
                         Class next = stack.remove(0);
                         if (result.add(next)) {
-                            for (Class<? extends Annotation> ac : annotationTypes(Arrays.asList(next.getDeclaredAnnotations()))) {
-                                if (!result.contains(ac) && !stack.contains(ac)) stack.add(ac);
+                            for (Class<? extends Annotation> ac : annotationTypes(
+                                    Arrays.asList(next.getDeclaredAnnotations()))) {
+                                if (!result.contains(ac) && !stack.contains(ac))
+                                    stack.add(ac);
                             }
                         }
                     }
-                    if (!result.contains(annotation)) return false;
+                    if (!result.contains(annotation))
+                        return false;
                 }
                 return true;
             }
@@ -375,6 +423,7 @@ public class ReflectionsTest {
 
     private Iterable<Class<? extends Annotation>> annotationTypes(Iterable<Annotation> annotations) {
         return ReflectionsIterables.transform(annotations, new Function<Annotation, Class<? extends Annotation>>() {
+            @Override
             public Class<? extends Annotation> apply(Annotation input) {
                 return input != null ? input.annotationType() : null;
             }

--- a/src/test/java/org/reflections8/TestModel.java
+++ b/src/test/java/org/reflections8/TestModel.java
@@ -8,64 +8,138 @@ import java.lang.annotation.Retention;
 /**
  *
  */
-@SuppressWarnings({"ALL"})
+@SuppressWarnings({ "ALL" })
 public interface TestModel {
-    public @Retention(RUNTIME) @Inherited @interface MAI1 {}
-    public @Retention(RUNTIME) @MAI1 @interface AI1 {}
-    public @AI1 interface I1 {}
-    public @Retention(RUNTIME) @Inherited @interface AI2 {}
-    public @AI2 interface I2 extends I1 {}
+    public @Retention(RUNTIME) @Inherited @interface MAI1 {
+    }
 
-    public @Retention(RUNTIME) @Inherited @interface AC1 {}
-    public @Retention(RUNTIME) @interface AC1n {}
-    public @AC1 @AC1n class C1 implements I2 {}
+    public @Retention(RUNTIME) @MAI1 @interface AI1 {
+    }
+
+    public @AI1 interface I1 {
+    }
+
+    public @Retention(RUNTIME) @Inherited @interface AI2 {
+    }
+
+    public @AI2 interface I2 extends I1 {
+    }
+
+    public @Retention(RUNTIME) @Inherited @interface AC1 {
+    }
+
+    public @Retention(RUNTIME) @interface AC1n {
+    }
+
+    public @AC1 @AC1n class C1 implements I2 {
+    }
+
     public @Retention(RUNTIME) @interface AC2 {
         public abstract String value();
     }
 
-    public @AC2("grr...") class C2 extends C1 {}
-    public @AC2("ugh?!") class C3 extends C1 {}
+    public @AC2("grr...") class C2 extends C1 {
+    }
+
+    public @AC2("ugh?!") class C3 extends C1 {
+    }
 
     public @Retention(RUNTIME) @interface AM1 {
         public abstract String value();
     }
+
     public @Retention(RUNTIME) @interface AF1 {
         public abstract String value();
     }
+
     public class C4 {
-        @AF1("1") private String f1;
-        @AF1("2") protected String f2;
+        @AF1("1")
+        private String f1;
+        @AF1("2")
+        protected String f2;
         protected String f3;
 
-        public C4() { }
-        @AM1("1") public C4(@AM1("1") String f1) { this.f1 = f1; }
+        public C4() {
+        }
 
-        @AM1("1") protected void m1() {}
-        @AM1("1") public void m1(int integer, String... strings) {}
-        @AM1("1") public void m1(int[][] integer, String[][] strings) {}
-        @AM1("2") public String m3() {return null;}
-        public String m4(@AM1("2") String string) {return null;}
-        public C3 c2toC3(C2 c2) {return null;}
-        public int add(int i1, int i2) { return i1+i2; }
+        @AM1("1")
+        public C4(@AM1("1") String f1) {
+            this.f1 = f1;
+        }
+
+        @AM1("1")
+        protected void m1() {
+        }
+
+        @AM1("1")
+        public void m1(int integer, String... strings) {
+        }
+
+        @AM1("1")
+        public void m1(int[][] integer, String[][] strings) {
+        }
+
+        @AM1("2")
+        public String m3() {
+            return null;
+        }
+
+        public String m4(@AM1("2") String string) {
+            return null;
+        }
+
+        public C3 c2toC3(C2 c2) {
+            return null;
+        }
+
+        public int add(int i1, int i2) {
+            return i1 + i2;
+        }
+
+        public void print(String s) {
+            Runnable run = () -> {
+            };
+        }
     }
-    
-    public class C5 extends C3 {}
-    public @AC2("ugh?!") interface I3 {}
-    public class C6 implements I3 {}
 
-    public @Retention(RUNTIME) @AC2("ugh?!") @interface AC3 { }
-    public @AC3 class C7 {}
+    public class C5 extends C3 {
+    }
+
+    public @AC2("ugh?!") interface I3 {
+    }
+
+    public class C6 implements I3 {
+    }
+
+    public @Retention(RUNTIME) @AC2("ugh?!") @interface AC3 {
+    }
+
+    public @AC3 class C7 {
+    }
 
     public interface Usage {
         public static class C1 {
             C2 c2 = new C2();
-            public C1() { }
-            public C1(C2 c2) { this.c2 = c2; }
-            public void method() { c2.method(); }
-            public void method(String string) { c2.method(); }
+
+            public C1() {
+            }
+
+            public C1(C2 c2) {
+                this.c2 = c2;
+            }
+
+            public void method() {
+                c2.method();
+            }
+
+            public void method(String string) {
+                c2.method();
+            }
         }
+
         public static class C2 {
             C1 c1 = new C1();
+
             public void method() {
                 c1 = new C1();
                 c1 = new C1(this);

--- a/src/test/java/org/reflections8/TestModel.java
+++ b/src/test/java/org/reflections8/TestModel.java
@@ -95,11 +95,6 @@ public interface TestModel {
         public int add(int i1, int i2) {
             return i1 + i2;
         }
-
-        public void print(String s) {
-            Runnable run = () -> {
-            };
-        }
     }
 
     public class C5 extends C3 {
@@ -146,6 +141,13 @@ public interface TestModel {
                 c1.method();
                 c1.method("");
             }
+        }
+    }
+
+    public class C8 {
+        public void print() {
+            Runnable run = () -> {
+            };
         }
     }
 }

--- a/src/test/java/org/reflections8/VfsTest.java
+++ b/src/test/java/org/reflections8/VfsTest.java
@@ -191,7 +191,7 @@ public class VfsTest {
         assertTrue(directoryInJarUrl.toString().contains(".jar!"));
 
         String directoryInJarPath = directoryInJarUrl.toExternalForm().replaceFirst("jar:", "");
-        int start = directoryInJarPath.indexOf(":") + 2;
+        int start = directoryInJarPath.indexOf(":") + (File.separator.equals("/") ? 1 : 2);
         int end = directoryInJarPath.indexOf(".jar!") + 4;
         String expectedJarFile = directoryInJarPath.substring(start, end);
 

--- a/src/test/java/org/reflections8/util/UtilsTest.java
+++ b/src/test/java/org/reflections8/util/UtilsTest.java
@@ -1,0 +1,21 @@
+package org.reflections8.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+import org.reflections8.TestModel.C8;
+
+public class UtilsTest {
+
+    @Test
+    public void testGetMemberFromDescriptorStringClassLoaderArray() {
+        Method[] declaredMethods = C8.class.getDeclaredMethods();
+        for (Method method : declaredMethods) {
+            String expectedString = method.toString();
+            String actualString = Utils.getMemberFromDescriptor(expectedString).toString();
+            assertEquals(expectedString, actualString);
+        }
+    }
+}


### PR DESCRIPTION
Don't know why diff detects lot of changes.
It was modified only method:
public static Member getMemberFromDescriptor(String descriptor, Optional<ClassLoader[]> classLoaders) throws ReflectionsException {

lines 72-74 added this:
`    int endsWithLambda = memberKey.lastIndexOf(".lambda");
    if (endsWithLambda > -1) {
      className = className.substring(0, endsWithLambda);
    }`

and lines 95-100 added this: 
`        } else if (endsWithLambda == -1) {
          return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes) : aClass.getDeclaredMethod(memberName, parameterTypes);
        } else {
          memberName = new StringBuilder("lambda$").append(memberName).toString();
          return aClass.isInterface() ? aClass.getMethod(memberName, parameterTypes) : Class.getDeclaredMethod(memberName, parameterTypes);
        }`
 